### PR TITLE
Encode quartus 'synthesis' metacomments into verilator tags

### DIFF
--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -126,6 +126,7 @@ public:
         VARHIDDEN,      // Hiding variable
         WIDTH,          // Width mismatch
         WIDTHCONCAT,    // Unsized numbers/parameters in concatenations
+        VLTAG,          // Warn when attach verilator tag to a node
         _ENUM_MAX
         // ***Add new elements below also***
     };
@@ -169,7 +170,7 @@ public:
             "UNDRIVEN", "UNOPT", "UNOPTFLAT", "UNOPTTHREADS",
             "UNPACKED", "UNSIGNED", "UNUSED",
             "USERERROR", "USERFATAL", "USERINFO", "USERWARN",
-            "VARHIDDEN", "WIDTH", "WIDTHCONCAT",
+            "VARHIDDEN", "WIDTH", "WIDTHCONCAT", "VLTAG",
             " MAX"
         };
         // clang-format on

--- a/src/V3PreProc.cpp
+++ b/src/V3PreProc.cpp
@@ -483,8 +483,14 @@ void V3PreProcImp::comment(const string& text) {
             if (!printed) insertUnreadback("/*verilator " + cmd + "*/");
         }
     } else if (preserve_all) {
-        if (commentTokenMatch(cmd /*ref*/, "synthesis")) {
-            if (!printed) insertUnreadback("/*verilator tag synthesis " + cmd + "*/");
+        if (commentTokenMatch(cmd /*ref*/, "synthesis") && !printed) {
+            if (cmd.find("translate_off") != string::npos) {
+                ; // skip translate_off
+            } else if (cmd.find("translate_on") != string::npos) {
+                ; // skip translate_on
+            } else {
+                insertUnreadback("/*verilator tag synthesis " + cmd + " */");
+            }
         }
     }
 }


### PR DESCRIPTION
We want to preserve some of the 'synthesis' metacomments in the output.
Verilator can only transform existing metacomments into some verilator
ones but not keeping the metacomments throughout the pipeline (at least
not available in the XML output).

To access those metacomments later in pyverilog, this comment encode
certain metacomments starting with 'synthesis' (quartus specific) into
verilator tags, which will later appear in XML as an attribute "tag".

While parsing the input (system) verilog code, parser will warn such
encoding behaviour. But note that not every metacomments imported will
shown in the output XML because of verilator compilation.