### PR TITLE
Support verilator tags for syscalls.

### DIFF
--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -3759,6 +3759,7 @@ class AstDisplay final : public AstNodeStmt {
     // Children: SFORMATF to generate print string
 private:
     AstDisplayType m_displayType;
+    string m_tag;
 
 public:
     AstDisplay(FileLine* fl, AstDisplayType dispType, const string& text, AstNode* filep,
@@ -3805,6 +3806,8 @@ public:
     AstSFormatF* fmtp() const { return VN_CAST(op1p(), SFormatF); }
     AstNode* filep() const { return op3p(); }
     void filep(AstNodeVarRef* nodep) { setNOp3p(nodep); }
+    virtual void tag(const string& text) override { m_tag = text; }
+    virtual string tag() const override { return m_tag; }
 };
 
 class AstDumpCtl final : public AstNodeStmt {

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -3515,6 +3515,7 @@ task_subroutine_callNoMethod<nodep>:	// function_subroutine_callNoMethod (as tas
 	//			// can call as method and yWITH without parenthesis
 	|	id yWITH__PAREN '(' expr ')'		{ $$ = new AstWithParse($2, true, new AstFuncRef($<fl>1, *$1, nullptr), $4); }
 	|	system_t_call				{ $$ = $1; }
+	|	system_t_call {PARSEP->tagNodep($1);} vlTag				{ $$ = $1; }
 	//			// IEEE: method_call requires a "." so is in expr
 	//			// IEEE: ['std::'] not needed, as normal std package resolution will find it
 	//			// IEEE: randomize_call


### PR DESCRIPTION
You can now annotate syscalls (e.g. display) with special metacomments.
Like `$display(xxx) /* verilator tag debug_display */`.
This is for selecting specific debugging-related $display in our benchmarks.